### PR TITLE
Update make_dataset.py for skiping non .binary

### DIFF
--- a/data_gen/merl/make_dataset.py
+++ b/data_gen/merl/make_dataset.py
@@ -72,6 +72,9 @@ def main(_):
 
     brdf_paths = xm.os.sortglob(FLAGS.indir)
     for i, path in enumerate(tqdm(brdf_paths, desc="Training & Validation")):
+        if not path.endswith('.binary'):
+            continue
+            
         brdf = MERL(path=path)
 
         rusink = brdf.tbl[:, :3]


### PR DESCRIPTION
I was getting an error when running the MERL dataset conversion code because `Readme.txt` file exists in the original dataset folder downloaded from https://cdfg.csail.mit.edu/wojciech/brdfdatabase